### PR TITLE
Clarified documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,21 @@ Use `xoauth2.createXOAuth2Generator(options)` to initialize Token Generator
 
 Possible options values:
 
-  * **user** User e-mail address
-  * **accessUrl** Optional Endpoint for token genration (defaults to *https://accounts.google.com/o/oauth2/token*)
-  * **clientId** Client ID value
-  * **clientSecret** Client secret value
-  * **refreshToken** Refresh token for an user
-  * **accessToken** Optional initial access token. If not set, a new one will be generated
-  * **timeout** Optional timeout for the initial access token
+  * **user** _(Required)_ User e-mail address
+  * **accessUrl** _(Optional)_ Endpoint for token generation (defaults to *https://accounts.google.com/o/oauth2/token*)
+  * **clientId** _(Required)_ Client ID value
+  * **clientSecret** _(Required)_ Client secret value
+  * **refreshToken** _(Required)_ Refresh token for an user
+  * **accessToken** _(Optional)_ initial access token. If not set, a new one will be generated
+  * **timeout** _(Optional)_ timestamp for when the initial access token times out. In **milliseconds** after 1.1.1970.
 
-See https://developers.google.com/accounts/docs/OAuth2WebServer#offline for generating the required credentials
+See [https://developers.google.com/accounts/docs/OAuth2WebServer#offline]() for generating the required credentials
 
 ### Methods
 
 #### Request an access token
 
-Use `xoauth2obj.getToken(callback)` to get an access token. If a cached token is found and it should not be expired yet, the
-cached value will be used.
+Use `xoauth2obj.getToken(callback)` to get an access token. If a cached token is found and it should not be expired yet, the cached value will be used.
 
 #### Request for generating a new access token
 
@@ -47,7 +46,7 @@ If a new token value has been set, `'token'` event is emitted.
     xoauth2obj.on("token", function(token){
         console.log("User: ", token.user); // e-mail address
         console.log("New access token: ", token.accessToken);
-        console.log("New access token timeout: ", token.timeout); // timestamp in second
+        console.log("New access token timeout: ", token.timeout); // timestamp after 1.1.1970 in seconds
     });
 
 ### Example

--- a/index.js
+++ b/index.js
@@ -28,12 +28,13 @@ module.exports.createXOAuth2Generator = function(options){
  *
  * @constructor
  * @param {Object} options Client information for token generation
- * @param {String} options.user User e-mail address
- * @param {String} options.token Existing OAuth2 token
- * @param {String} [options.accessUrl="https://accounts.google.com/o/oauth2/token"] Endpoint for token genration
- * @param {String} options.clientId Client ID value
- * @param {String} options.clientSecret Client secret value
- * @param {String} options.refreshToken Refresh token for an user
+ * @param {String} options.user         (Required) User e-mail address
+ * @param {String} options.clientId     (Required) Client ID value
+ * @param {String} options.clientSecret (Required) Client secret value
+ * @param {String} options.refreshToken (Required) Refresh token for an user
+ * @param {String} options.accessUrl    (Optional) Endpoint for token generation, defaults to "https://accounts.google.com/o/oauth2/token"
+ * @param {String} options.accessToken  (Optional) An existing valid accessToken
+ * @param {int}    options.timeout      (Optional) A timestamp in milliseconds after 1.1.1970 when the given accessToken expires
  */
 function XOAuth2Generator(options){
     Stream.call(this);
@@ -65,6 +66,8 @@ XOAuth2Generator.prototype.getToken = function(callback){
  *
  * @param {String} accessToken New access token
  * @param {Number} timeout Access token lifetime in seconds
+ *
+ * Emits 'token': { user: User email-address, accessToken: the new accessToken, timeout: Timestamp in seconds after 1.1.1970 }
  */
 XOAuth2Generator.prototype.updateToken = function(accessToken, timeout){
     this.token = this.buildXOAuth2Token(accessToken);


### PR DESCRIPTION
I clarified the documentation regarding the timestamps (because the initial is given in milliseconds whereas the emitted one is in seconds) and the parameters.
