### PR TITLE
Add support for Google service accounts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ Possible options values:
 
 See [https://developers.google.com/identity/protocols/OAuth2WebServer#offline](https://developers.google.com/identity/protocols/OAuth2WebServer#offline) for generating the required credentials
 
+For Google service account the option values are:
+
+  * **service** _(Required)_ Service account email.
+  * **user** _(Required)_ User e-mail address
+  * **scope** _(Required)_ OAuth2 scope.
+  * **privateKey** _(Required)_ Private key issued for the service account in PEM format, as a string.
+  * **serviceRequestTimeout** _(Optional)_ Expiration value to use in the token request in **seconds**. Maximum is 3600.
+  * **accessUrl** _(Optional)_ Endpoint for token generation (defaults to *https://accounts.google.com/o/oauth2/token*)
+  * **accessToken** _(Optional)_ initial access token. If not set, a new one will be generated
+  * **timeout** _(Optional)_ TTL in **seconds**
+  * **customHeaders** _(Optional)_ custom headers to send during token generation request
+  * **customParams** _(Optional)_ custom payload to send on getToken request
+
 ### Methods
 
 #### Request an access token
@@ -67,6 +80,14 @@ If a new token value has been set, `'token'` event is emitted.
         customPayload: {
           "payloadParamName": "payloadValue"
         }
+    });
+
+    // ... or for a Google service account
+    xoauth2gen = xoauth2.createXOAuth2Generator({
+        user: "user@gmail.com",
+        service: '{Service Email Address}',
+        scope: 'https://mail.google.com/',
+        privateKey: '{Private Key in PEM format}'
     });
 
     // SMTP/IMAP

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "scripts": {
     "test": "grunt"
   },
-  "dependencies": {
-    "jsonwebtoken": "^7.0.1"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/andris9/xoauth2.git"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "grunt"
   },
+  "dependencies": {
+    "jsonwebtoken": "^7.0.1"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/andris9/xoauth2.git"

--- a/src/xoauth2.js
+++ b/src/xoauth2.js
@@ -6,6 +6,7 @@ var querystring = require('querystring');
 var http = require('http');
 var https = require('https');
 var urllib = require('url');
+var jwt = require('jsonwebtoken');
 
 /**
  * Wrapper for new XOAuth2Generator.
@@ -43,6 +44,15 @@ module.exports.createXOAuth2Generator = function(options) {
 function XOAuth2Generator(options) {
     Stream.call(this);
     this.options = options || {};
+
+    if (options && options.service) {
+        if (!options.scope || !options.privateKey || !options.user) {
+            throw new Error('Options "scope", "privateKey" and "user" are required for service account!');
+        }
+
+        var serviceRequestTimeout = Math.min(Math.max(Number(this.options.serviceRequestTimeout) || 0, 0), 3600);
+        this.options.serviceRequestTimeout = serviceRequestTimeout || 5 * 60;
+    }
 
     this.options.accessUrl = this.options.accessUrl || 'https://accounts.google.com/o/oauth2/token';
     this.options.customHeaders = this.options.customHeaders || {};
@@ -95,12 +105,33 @@ XOAuth2Generator.prototype.updateToken = function(accessToken, timeout) {
  * @param {Function} callback Callback function with error object and token string
  */
 XOAuth2Generator.prototype.generateToken = function(callback) {
-    var urlOptions = {
+    var urlOptions;
+    if (this.options.service) {
+        // service account - https://developers.google.com/identity/protocols/OAuth2ServiceAccount
+        var iat = Math.floor(Date.now() / 1000); // unix time
+        var token = jwt.sign({
+            iss: this.options.service,
+            scope: this.options.scope,
+            sub: this.options.user,
+            aud: this.options.accessUrl,
+            iat: iat,
+            exp: iat + this.options.serviceRequestTimeout,
+        }, this.options.privateKey, { algorithm: 'RS256' });
+
+        urlOptions = {
+            grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+            assertion: token
+        };
+    }
+    else {
+        // web app - https://developers.google.com/identity/protocols/OAuth2WebServer
+        urlOptions = {
             client_id: this.options.clientId || '',
             client_secret: this.options.clientSecret || '',
             refresh_token: this.options.refreshToken,
             grant_type: 'refresh_token'
         };
+    }
 
     for (var param in this.options.customParams) {
         urlOptions[param] = this.options.customParams[param];


### PR DESCRIPTION
This implements token request as described in https://developers.google.com/identity/protocols/OAuth2ServiceAccount#authorizingrequests

This behavior is triggered by using the option 'service' in createXOAuth2Generator(). See
README.md for more info.
